### PR TITLE
Use helm deployment name instead of cluster name

### DIFF
--- a/charts/enterprise-metrics/Chart.yaml
+++ b/charts/enterprise-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.0
+version: 1.0.1
 appVersion: v1.1.2
 description: 'Grafana Enterprise Metrics'
 engine: gotpl

--- a/charts/enterprise-metrics/README.md
+++ b/charts/enterprise-metrics/README.md
@@ -33,7 +33,7 @@ $ # Add the repository
 $ helm repo add grafana https://grafana.github.io/helm-charts
 $ helm repo update
 $ # Perform install
-$ helm install <cluster name> grafana/enterprise-metrics --set-file 'license.contents=./license.jwt'
+$ helm install <helm deployment name> grafana/enterprise-metrics --set-file 'license.contents=./license.jwt'
 ```
 
 As part of this chart many different pods and services are installed which all
@@ -64,7 +64,7 @@ object storage service for production deployments.
 To deploy a cluster using `small.yaml` values file:
 
 ```console
-$ helm install <cluster name> grafana/enterprise-metrics --set-file 'license.contents=./license.jwt' -f small.yaml
+$ helm install <helm deployment name> grafana/enterprise-metrics --set-file 'license.contents=./license.jwt' -f small.yaml
 ```
 
 ### Large
@@ -86,7 +86,7 @@ object storage service for production deployments.
 To deploy a cluster using the `large.yaml` values file:
 
 ```console
-$ helm install <cluster name> grafana/enterprise-metrics --set-file 'license.contents=./license.jwt' -f large.yaml
+$ helm install <helm deployment name> grafana/enterprise-metrics --set-file 'license.contents=./license.jwt' -f large.yaml
 ```
 
 # Development


### PR DESCRIPTION
I think that makes it clearer. For a moment I got myself confused,
until I realised I need to set the cluster name like that:

```
--set "config.cluster_name=<cluster name>"
```

Signed-off-by: Christian Simon <simon@swine.de>